### PR TITLE
Fixed the env var for grid url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -114,8 +114,8 @@ runs:
 
     - run: |
         if [ ! -z "${{ inputs.grid-url }}" ]; then 
-          export grid-url=${{ inputs.grid-url }}
-          echo "grid-url=${{ inputs.grid-url }}" >> $GITHUB_ENV 
+          export GRID_URL=${{ inputs.grid-url }}
+          echo "GRID_URL=${{ inputs.grid-url }}" >> $GITHUB_ENV
         fi
       shell: bash
 


### PR DESCRIPTION
If the value for the input `grid-url` is provided, the action fails because of the environment variable name. This PR fixes the naming.